### PR TITLE
Uf 9908 add prefix to orgnr for byggr request

### DIFF
--- a/src/main/java/se/sundsvall/byggrintegrator/integration/byggr/ByggrIntegrationMapper.java
+++ b/src/main/java/se/sundsvall/byggrintegrator/integration/byggr/ByggrIntegrationMapper.java
@@ -86,7 +86,7 @@ public class ByggrIntegrationMapper {
 
 		// Collect the info we want from errands that have a valid event
 		return errands.stream()
-			.filter(arende -> hasValidHandelseList(arende.getHandelseLista().getHandelse()))
+			.filter(arende -> hasValidHandelseList(arende.getDnr(), arende.getHandelseLista().getHandelse()))
 			.map(this::toByggErrandDto)
 			.toList();
 	}
@@ -150,7 +150,9 @@ public class ByggrIntegrationMapper {
 			.anyMatch(roller -> roller.stream().anyMatch(roles::contains));
 	}
 
-	private boolean hasValidHandelseList(List<Handelse> handelseList) {
+	private boolean hasValidHandelseList(String dnr, List<Handelse> handelseList) {
+		LOG.info("Validating case with dnr {}", dnr);
+
 		var hasValidEvent = false;
 		var hasInvalidEvent = false;
 

--- a/src/main/java/se/sundsvall/byggrintegrator/service/ByggrIntegratorService.java
+++ b/src/main/java/se/sundsvall/byggrintegrator/service/ByggrIntegratorService.java
@@ -7,6 +7,7 @@ import static org.springframework.util.StreamUtils.copy;
 import static org.zalando.problem.Status.INTERNAL_SERVER_ERROR;
 import static org.zalando.problem.Status.NOT_FOUND;
 import static se.sundsvall.byggrintegrator.service.LegalIdUtility.addHyphen;
+import static se.sundsvall.byggrintegrator.service.LegalIdUtility.prefixOrgnbr;
 import static se.sundsvall.byggrintegrator.service.MimeTypeUtility.detectMimeType;
 
 import java.io.ByteArrayInputStream;
@@ -55,7 +56,10 @@ public class ByggrIntegratorService {
 			throw createProblem(NOT_FOUND, ERROR_ROLES_NOT_FOUND);
 		}
 
-		final var matches = byggrIntegration.getErrands(addHyphen(identifier), roles); // Add hyphen to identifier as ByggR integration formats legal id that way
+		// Prefix identifier if it contains organisation legal id and add hyphen to identifier as ByggR integration formats
+		// legal id that way
+		final var processedIdentifier = addHyphen(prefixOrgnbr(identifier));
+		final var matches = byggrIntegration.getErrands(processedIdentifier, roles);
 
 		final var byggrErrandList = byggrIntegrationMapper.mapToNeighborhoodNotifications(matches);
 
@@ -63,11 +67,13 @@ public class ByggrIntegratorService {
 	}
 
 	public List<KeyValue> findApplicantErrands(String identifier) {
-		final var identifierWithHyphen = addHyphen(identifier); // Add hyphen to identifier as ByggR integration formats legal id that way
+		// Prefix identifier if it contains organisation legal id and add hyphen to identifier as ByggR integration formats
+		// legal id that way
+		final var processedIdentifier = addHyphen(prefixOrgnbr(identifier));
 
-		final var matches = byggrIntegration.getErrands(identifierWithHyphen, null);
+		final var matches = byggrIntegration.getErrands(processedIdentifier, null);
 
-		final var byggrErrandList = byggrIntegrationMapper.mapToApplicantErrands(matches, identifierWithHyphen);
+		final var byggrErrandList = byggrIntegrationMapper.mapToApplicantErrands(matches, processedIdentifier);
 
 		return apiResponseMapper.mapToKeyValueResponseList(byggrErrandList);
 	}

--- a/src/main/java/se/sundsvall/byggrintegrator/service/LegalIdUtility.java
+++ b/src/main/java/se/sundsvall/byggrintegrator/service/LegalIdUtility.java
@@ -10,6 +10,22 @@ public class LegalIdUtility {
 	private LegalIdUtility() {}
 
 	/**
+	 * Method for adding 16 as prefix if incoming legalId passes the following tests:
+	 * - string is not null
+	 * - string has a character length of exactly 10
+	 * If sent in string doesn't pass the test above, the string is returned untouched.
+	 *
+	 * @param legalId string
+	 * @return string prefixed with 16 or untouched string if the it does not match the tests above
+	 */
+	public static String prefixOrgnbr(String legalId) {
+		return ofNullable(legalId)
+			.filter(string -> string.length() == 10)
+			.map(string -> "16" + string)
+			.orElse(legalId);
+	}
+
+	/**
 	 * Method to add a hyphen after position 4 when string passes the following tests:
 	 * - string is not null
 	 * - string has a minimum length of 4

--- a/src/test/java/se/sundsvall/byggrintegrator/service/LegalIdUtilityTest.java
+++ b/src/test/java/se/sundsvall/byggrintegrator/service/LegalIdUtilityTest.java
@@ -32,7 +32,7 @@ class LegalIdUtilityTest {
 			Arguments.of("1234567", "1234567"),
 			Arguments.of("12345678", "12345678"),
 			Arguments.of("123456789", "123456789"),
-			Arguments.of("1234567890", "161234567890"), // This is the only string that should be tamered with
+			Arguments.of("1234567890", "161234567890"), // This is the only string that should be tampered with
 			Arguments.of("12345678901", "12345678901"),
 			Arguments.of("123456789012", "123456789012"),
 			Arguments.of("1234567890123", "1234567890123"));

--- a/src/test/java/se/sundsvall/byggrintegrator/service/LegalIdUtilityTest.java
+++ b/src/test/java/se/sundsvall/byggrintegrator/service/LegalIdUtilityTest.java
@@ -2,6 +2,7 @@ package se.sundsvall.byggrintegrator.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static se.sundsvall.byggrintegrator.service.LegalIdUtility.addHyphen;
+import static se.sundsvall.byggrintegrator.service.LegalIdUtility.prefixOrgnbr;
 
 import java.util.stream.Stream;
 
@@ -11,6 +12,31 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class LegalIdUtilityTest {
+
+	@ParameterizedTest
+	@MethodSource("prefixArgumentProvider")
+	void testPrefixOrgnbr(String value, String expected) {
+		assertThat(prefixOrgnbr(value)).isEqualTo(expected);
+	}
+
+	private static Stream<Arguments> prefixArgumentProvider() {
+		return Stream.of(
+			Arguments.of(null, null),
+			Arguments.of("", ""),
+			Arguments.of("1", "1"),
+			Arguments.of("12", "12"),
+			Arguments.of("123", "123"),
+			Arguments.of("1234", "1234"),
+			Arguments.of("12345", "12345"),
+			Arguments.of("123456", "123456"),
+			Arguments.of("1234567", "1234567"),
+			Arguments.of("12345678", "12345678"),
+			Arguments.of("123456789", "123456789"),
+			Arguments.of("1234567890", "161234567890"), // This is the only string that should be tamered with
+			Arguments.of("12345678901", "12345678901"),
+			Arguments.of("123456789012", "123456789012"),
+			Arguments.of("1234567890123", "1234567890123"));
+	}
 
 	@Test
 	void testAddHyphenOnNull() {


### PR DESCRIPTION
- Added logic for adding a prefix to legal id for organisations, as the service validates that organizational legal ids have a length of 10 but ByggR requires a length of 12 (prefixing the legal id with 16)