### PR TITLE
UF-10659: Adjusted mapper to compensate for duplicate documents

### DIFF
--- a/src/main/java/se/sundsvall/byggrintegrator/integration/byggr/ByggrIntegrationMapper.java
+++ b/src/main/java/se/sundsvall/byggrintegrator/integration/byggr/ByggrIntegrationMapper.java
@@ -16,11 +16,6 @@ import javax.xml.datatype.XMLGregorianCalendar;
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.stereotype.Component;
 
-import se.sundsvall.byggrintegrator.model.ByggrErrandDto;
-import se.sundsvall.byggrintegrator.model.ByggrErrandDto.Event;
-import se.sundsvall.byggrintegrator.model.ByggrErrandDto.Stakeholder;
-import se.sundsvall.byggrintegrator.service.util.ByggrFilterUtility;
-
 import generated.se.sundsvall.arendeexport.Arende;
 import generated.se.sundsvall.arendeexport.ArendeFastighet;
 import generated.se.sundsvall.arendeexport.ArendeIntressent;
@@ -42,6 +37,10 @@ import generated.se.sundsvall.arendeexport.HandelseIntressent;
 import generated.se.sundsvall.arendeexport.ObjectFactory;
 import generated.se.sundsvall.arendeexport.RollTyp;
 import generated.se.sundsvall.arendeexport.StatusFilter;
+import se.sundsvall.byggrintegrator.model.ByggrErrandDto;
+import se.sundsvall.byggrintegrator.model.ByggrErrandDto.Event;
+import se.sundsvall.byggrintegrator.model.ByggrErrandDto.Stakeholder;
+import se.sundsvall.byggrintegrator.service.util.ByggrFilterUtility;
 
 /**
  * Mapper for handling mappings between ByggR responses and the internal dto class used in the service layer
@@ -159,7 +158,7 @@ public class ByggrIntegrationMapper {
 			.filter(document -> Objects.nonNull(document.getDokId()))
 			.filter(document -> Objects.nonNull(document.getNamn()))
 			.map(document -> Map.entry(document.getDokId(), document.getNamn()))
-			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (a1, a2) -> a1)); // In case of duplicate dokIds within the event, just pick the first one of them
 	}
 
 	private List<Stakeholder> toStakeholders(ArrayOfHandelseIntressent2 intressenter) {

--- a/src/test/java/se/sundsvall/byggrintegrator/TestObjectFactory.java
+++ b/src/test/java/se/sundsvall/byggrintegrator/TestObjectFactory.java
@@ -7,9 +7,6 @@ import java.util.List;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 
-import se.sundsvall.byggrintegrator.model.ByggrErrandDto;
-import se.sundsvall.byggrintegrator.model.ByggrErrandDto.Event;
-
 import generated.se.sundsvall.arendeexport.AbstractArendeObjekt;
 import generated.se.sundsvall.arendeexport.Arende;
 import generated.se.sundsvall.arendeexport.ArrayOfAbstractArendeObjekt2;
@@ -21,6 +18,8 @@ import generated.se.sundsvall.arendeexport.GetArendeResponse;
 import generated.se.sundsvall.arendeexport.GetDocumentResponse;
 import generated.se.sundsvall.arendeexport.GetRelateradeArendenByPersOrgNrAndRoleResponse;
 import generated.se.sundsvall.arendeexport.ObjectFactory;
+import se.sundsvall.byggrintegrator.model.ByggrErrandDto;
+import se.sundsvall.byggrintegrator.model.ByggrErrandDto.Event;
 
 public final class TestObjectFactory {
 
@@ -135,6 +134,11 @@ public final class TestObjectFactory {
 		final var arrayOfHandelseHandling = OBJECT_FACTORY.createArrayOfHandelseHandling();
 		return arrayOfHandelseHandling
 			.withHandling(OBJECT_FACTORY.createHandelseHandling()
+				.withTyp(WANTED_DOKUMENT_TYPE)
+				.withDokument(OBJECT_FACTORY.createDokument()
+					.withDokId(WANTED_DOCUMENT_ID)
+					.withNamn(WANTED_DOCUMENT_NAME)))
+			.withHandling(OBJECT_FACTORY.createHandelseHandling() // Create a handling with a duplicate of document, to verify that only one remains after mapping
 				.withTyp(WANTED_DOKUMENT_TYPE)
 				.withDokument(OBJECT_FACTORY.createDokument()
 					.withDokId(WANTED_DOCUMENT_ID)

--- a/src/test/java/se/sundsvall/byggrintegrator/integration/byggr/ByggrIntegrationMapperTest.java
+++ b/src/test/java/se/sundsvall/byggrintegrator/integration/byggr/ByggrIntegrationMapperTest.java
@@ -23,12 +23,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
+import generated.se.sundsvall.arendeexport.RollTyp;
+import generated.se.sundsvall.arendeexport.StatusFilter;
 import se.sundsvall.byggrintegrator.Application;
 import se.sundsvall.byggrintegrator.model.ByggrErrandDto;
 import se.sundsvall.byggrintegrator.model.ByggrErrandDto.Event;
-
-import generated.se.sundsvall.arendeexport.RollTyp;
-import generated.se.sundsvall.arendeexport.StatusFilter;
 
 @SpringBootTest(classes = Application.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("junit")
@@ -77,12 +76,14 @@ class ByggrIntegrationMapperTest {
 				assertThat(event.getEventType()).isEqualTo(HANDELSETYP_GRANHO);
 				assertThat(event.getEventSubtype()).isEqualTo(HANDELSESLAG_GRAUTS);
 				assertThat(event.getEventDate()).isEqualTo(LocalDate.now());
+				assertThat(event.getFiles()).isNotEmpty().containsExactlyInAnyOrderEntriesOf(Map.of("wantedDocumentId", "wantedDocumentName"));
 				assertEventStakeholders(event);
 			}, event -> {
 				assertThat(event.getId()).isEqualTo(2);
 				assertThat(event.getEventType()).isEqualTo(HANDELSETYP_GRANHO);
 				assertThat(event.getEventSubtype()).isEqualTo(HANDELSESLAG_GRAUTS);
 				assertThat(event.getEventDate()).isEqualTo(LocalDate.now());
+				assertThat(event.getFiles()).isEmpty();
 				assertEventStakeholders(event);
 			});
 		}, errand -> {
@@ -93,12 +94,14 @@ class ByggrIntegrationMapperTest {
 				assertThat(event.getEventType()).isEqualTo(HANDELSETYP_GRANHO);
 				assertThat(event.getEventSubtype()).isEqualTo(HANDELSESLAG_GRASVA);
 				assertThat(event.getEventDate()).isEqualTo(LocalDate.now());
+				assertThat(event.getFiles()).isNotEmpty().containsExactlyInAnyOrderEntriesOf(Map.of("wantedDocumentId", "wantedDocumentName"));
 				assertEventStakeholders(event);
 			}, event -> {
 				assertThat(event.getId()).isEqualTo(2);
 				assertThat(event.getEventType()).isEqualTo(HANDELSETYP_GRANHO);
 				assertThat(event.getEventSubtype()).isEqualTo(HANDELSESLAG_GRAUTS);
 				assertThat(event.getEventDate()).isEqualTo(LocalDate.now());
+				assertThat(event.getFiles()).isEmpty();
 				assertEventStakeholders(event);
 			});
 		});

--- a/src/test/java/se/sundsvall/byggrintegrator/service/ByggrIntegratorServiceTest.java
+++ b/src/test/java/se/sundsvall/byggrintegrator/service/ByggrIntegratorServiceTest.java
@@ -26,9 +26,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Stream;
 
-import jakarta.servlet.ServletOutputStream;
-import jakarta.servlet.http.HttpServletResponse;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -43,15 +40,16 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.zalando.problem.Status;
 import org.zalando.problem.ThrowableProblem;
 
+import generated.se.sundsvall.arendeexport.GetArendeResponse;
+import generated.se.sundsvall.arendeexport.ObjectFactory;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServletResponse;
 import se.sundsvall.byggrintegrator.TestObjectFactory;
 import se.sundsvall.byggrintegrator.integration.byggr.ByggrIntegration;
 import se.sundsvall.byggrintegrator.integration.byggr.ByggrIntegrationMapper;
 import se.sundsvall.byggrintegrator.model.ByggrErrandDto;
 import se.sundsvall.byggrintegrator.service.template.TemplateMapper;
 import se.sundsvall.byggrintegrator.service.util.ByggrFilterUtility;
-
-import generated.se.sundsvall.arendeexport.GetArendeResponse;
-import generated.se.sundsvall.arendeexport.ObjectFactory;
 
 @ExtendWith(MockitoExtension.class)
 class ByggrIntegratorServiceTest {
@@ -126,7 +124,7 @@ class ByggrIntegratorServiceTest {
 		verify(mockByggrIntegration).getErrands(processedIdentifier, ROLES);
 		verify(mockByggrIntegrationMapper).mapToByggrErrandDtos(response);
 		verify(mockByggrFilterUtility).filterNeighborhoodNotifications(anyList(), eq(processedIdentifier));
-		verify(mockByggrFilterUtility, times(6)).hasValidDocumentType(any());
+		verify(mockByggrFilterUtility, times(8)).hasValidDocumentType(any());
 		verify(mockApiResponseMapper).mapToNeighborhoodKeyValueResponseList(anyList());
 		verifyNoMoreInterations();
 	}
@@ -157,7 +155,7 @@ class ByggrIntegratorServiceTest {
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = {ORG_IDENTIFIER, PRIVATE_IDENTIFIER})
+	@ValueSource(strings = { ORG_IDENTIFIER, PRIVATE_IDENTIFIER })
 	void testFindNeighborhoodNotifications_noRoles_shouldThrow404(String identifier) {
 		// Arrange
 		when(mockByggrIntegration.getRoles()).thenReturn(emptyList());
@@ -225,22 +223,22 @@ class ByggrIntegratorServiceTest {
 		verify(mockByggrIntegrationMapper).mapToByggrErrandDtos(response);
 		verify(mockByggrFilterUtility).filterCasesForApplicant(anyList(), eq(processedIdentifier));
 		verify(mockApiResponseMapper).mapToKeyValueResponseList(anyList());
-		verify(mockByggrFilterUtility, times(6)).hasValidDocumentType(any());
+		verify(mockByggrFilterUtility, times(8)).hasValidDocumentType(any());
 		verifyNoMoreInterations();
 	}
 
 	@Test
 	void getPropertyDesignation() throws Exception {
 		setField(mockByggrIntegrationMapper, "filterUtility", mockByggrFilterUtility);
-		var dnr = "BYGG 2024-000123";
-		var byggrErrandDto = ByggrErrandDto.builder()
+		final var dnr = "BYGG 2024-000123";
+		final var byggrErrandDto = ByggrErrandDto.builder()
 			.build();
 
 		when(mockByggrIntegration.getErrand(dnr)).thenReturn(generateArendeResponse(dnr));
 		when(mockByggrIntegrationMapper.mapToByggrErrandDto(any())).thenReturn(byggrErrandDto);
 		when(mockTemplateMapper.getDescriptionAndPropertyDesignation(any(ByggrErrandDto.class))).thenReturn("RUNSVIK 1:22");
 
-		var propertyDesignation = service.getPropertyDesignation(dnr);
+		final var propertyDesignation = service.getPropertyDesignation(dnr);
 
 		assertThat(propertyDesignation).isNotNull().isEqualTo("RUNSVIK 1:22");
 		verify(mockByggrIntegration).getErrand(dnr);


### PR DESCRIPTION
- Adjusted mapper to compensate for duplicate documents found within the same event when mapping included documents for events

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
