### PR TITLE
HYDRAN-2436: fix neighborhood-notification filter to use KOMFASUTS

### DIFF
--- a/src/main/java/se/sundsvall/byggrintegrator/api/NeighborhoodNotificationResource.java
+++ b/src/main/java/se/sundsvall/byggrintegrator/api/NeighborhoodNotificationResource.java
@@ -45,7 +45,7 @@ class NeighborhoodNotificationResource {
 
 	@GetMapping(path = "/neighborhood-notifications/{identifier}/errands", produces = APPLICATION_JSON_VALUE)
 	@Operation(summary = "Lists all neighborhood notifications where the provided identifier is a stakeholder",
-		description = "Returns errands filtered by: valid GRANHO events with subtype GRAUTS or KOMFAST events with subtype KOMFASVA, excluding configured unwanted event types, matching the identifier as a stakeholder in events not older than 60 days",
+		description = "Returns errands filtered by: valid GRANHO events with subtype GRAUTS or KOMFAST events with subtype KOMFASUTS, excluding configured unwanted event types, matching the identifier as a stakeholder in events not older than 60 days",
 		responses = {
 			@ApiResponse(responseCode = "200", description = "Successful Operation", useReturnTypeSchema = true),
 			@ApiResponse(responseCode = "404", description = "Not Found", content = @Content(mediaType = APPLICATION_PROBLEM_JSON_VALUE, schema = @Schema(implementation = Problem.class)))

--- a/src/main/java/se/sundsvall/byggrintegrator/service/util/ByggrFilterUtility.java
+++ b/src/main/java/se/sundsvall/byggrintegrator/service/util/ByggrFilterUtility.java
@@ -36,7 +36,7 @@ import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
  * notifications. If an errand contains an event with event type matching one of the defined value(s), the errand is
  * filtered out from the
  * returned response. If property is not set, then no filtering is made. Observe that filtering is always done regarding
- * that the errand must have a valid event type/subtype pair (GRANHO/GRAUTS or KOMFAST/KOMFASVA) to be returned in the
+ * that the errand must have a valid event type/subtype pair (GRANHO/GRAUTS or KOMFAST/KOMFASUTS) to be returned in the
  * response.
  * <p>
  * The third setting (document-types unwanted-document-types) is used to filter documents when fetching a
@@ -51,7 +51,7 @@ public class ByggrFilterUtility {
 
 	private static final Map<String, String> WANTED_TYPE_SUBTYPE_PAIRS = Map.of(
 		"GRANHO", "GRAUTS",
-		"KOMFAST", "KOMFASVA");
+		"KOMFAST", "KOMFASUTS");
 
 	private final List<String> applicantRoles;
 	private final List<String> unwantedSubtypes;

--- a/src/main/java/se/sundsvall/byggrintegrator/service/util/ByggrFilterUtility.java
+++ b/src/main/java/se/sundsvall/byggrintegrator/service/util/ByggrFilterUtility.java
@@ -1,6 +1,7 @@
 package se.sundsvall.byggrintegrator.service.util;
 
 import generated.se.sundsvall.arendeexport.v8.HandelseHandling;
+import java.time.Clock;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -56,6 +57,7 @@ public class ByggrFilterUtility {
 	private final List<String> applicantRoles;
 	private final List<String> unwantedSubtypes;
 	private final List<String> unwantedDocumentTypes;
+	private final Clock clock = Clock.systemDefaultZone();
 
 	public ByggrFilterUtility(final ByggrFilterProperties byggrProperties) {
 		this.applicantRoles = ofNullable(byggrProperties)
@@ -144,7 +146,7 @@ public class ByggrFilterUtility {
 
 		final var filteredEvents = errand.getEvents().stream()
 			.filter(event -> isWantedTypePair(event.getEventType(), event.getEventSubtype()))
-			.filter(event -> ofNullable(event.getEventDate()).map(eventDate -> eventDate.isAfter(now().minusDays(61))).orElse(false)) // Events must have a date and not be older than 60 days to be included
+			.filter(event -> ofNullable(event.getEventDate()).map(eventDate -> eventDate.isAfter(now(clock).minusDays(61))).orElse(false)) // Events must have a date and not be older than 60 days to be included
 			.filter(event -> event.getStakeholders().stream().anyMatch(stakeholder -> LegalIdUtility.isEqual(stakeholder.getLegalId(), identifier)))
 			.toList();
 

--- a/src/main/java/se/sundsvall/byggrintegrator/service/util/ByggrFilterUtility.java
+++ b/src/main/java/se/sundsvall/byggrintegrator/service/util/ByggrFilterUtility.java
@@ -1,7 +1,6 @@
 package se.sundsvall.byggrintegrator.service.util;
 
 import generated.se.sundsvall.arendeexport.v8.HandelseHandling;
-import java.time.Clock;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -57,7 +56,6 @@ public class ByggrFilterUtility {
 	private final List<String> applicantRoles;
 	private final List<String> unwantedSubtypes;
 	private final List<String> unwantedDocumentTypes;
-	private final Clock clock = Clock.systemDefaultZone();
 
 	public ByggrFilterUtility(final ByggrFilterProperties byggrProperties) {
 		this.applicantRoles = ofNullable(byggrProperties)
@@ -146,7 +144,7 @@ public class ByggrFilterUtility {
 
 		final var filteredEvents = errand.getEvents().stream()
 			.filter(event -> isWantedTypePair(event.getEventType(), event.getEventSubtype()))
-			.filter(event -> ofNullable(event.getEventDate()).map(eventDate -> eventDate.isAfter(now(clock).minusDays(61))).orElse(false)) // Events must have a date and not be older than 60 days to be included
+			.filter(event -> ofNullable(event.getEventDate()).map(eventDate -> eventDate.isAfter(now().minusDays(61))).orElse(false)) // Events must have a date and not be older than 60 days to be included
 			.filter(event -> event.getStakeholders().stream().anyMatch(stakeholder -> LegalIdUtility.isEqual(stakeholder.getLegalId(), identifier)))
 			.toList();
 

--- a/src/main/resources/api/openapi.yaml
+++ b/src/main/resources/api/openapi.yaml
@@ -266,7 +266,7 @@ paths:
       summary: Lists all neighborhood notifications where the provided identifier
         is a stakeholder
       description: "Returns errands filtered by: valid GRANHO events with subtype\
-        \ GRAUTS or KOMFAST events with subtype KOMFASVA, excluding configured unwanted\
+        \ GRAUTS or KOMFAST events with subtype KOMFASUTS, excluding configured unwanted\
         \ event types, matching the identifier as a stakeholder in events not older\
         \ than 60 days"
       operationId: findNeighborhoodNotifications

--- a/src/test/java/se/sundsvall/byggrintegrator/service/util/ByggrFilterUtilityTest.java
+++ b/src/test/java/se/sundsvall/byggrintegrator/service/util/ByggrFilterUtilityTest.java
@@ -1,11 +1,8 @@
 package se.sundsvall.byggrintegrator.service.util;
 
-import java.time.Clock;
 import java.time.LocalDate;
-import java.time.ZoneOffset;
 import java.util.List;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -19,24 +16,20 @@ import se.sundsvall.byggrintegrator.model.ByggrErrandDto.Event;
 import se.sundsvall.byggrintegrator.model.ByggrErrandDto.Stakeholder;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mockStatic;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 @ExtendWith(MockitoExtension.class)
 class ByggrFilterUtilityTest {
 	private static final String STAKEHOLDER_LEGAL_ID = "stakeholderLegalId";
-	private static final LocalDate FIXED_DATE = LocalDate.of(2026, 6, 11);
-	private static final Clock FIXED_CLOCK = Clock.fixed(FIXED_DATE.atStartOfDay(ZoneOffset.UTC).toInstant(), ZoneOffset.UTC);
+	private static final LocalDate FIXED_TODAY = LocalDate.of(2026, 6, 11);
 
 	@Mock
 	private ByggrFilterProperties byggrFilterPropertiesMock;
 
 	@InjectMocks
 	private ByggrFilterUtility byggrFilterUtility;
-
-	@BeforeEach
-	void setUp() {
-		setField(byggrFilterUtility, "clock", FIXED_CLOCK);
-	}
 
 	private static Stream<Arguments> validEventArgumentProvider() {
 		return Stream.of(
@@ -57,25 +50,25 @@ class ByggrFilterUtilityTest {
 
 	private static Stream<Arguments> filterNeighborhoodNotificationsArgumentProvider() {
 		return Stream.of(
-			Arguments.of(List.of(createEvent(null, "GRAUTS", FIXED_DATE)), STAKEHOLDER_LEGAL_ID, 0, 0),
-			Arguments.of(List.of(createEvent("GRANHO", null, FIXED_DATE)), STAKEHOLDER_LEGAL_ID, 0, 0),
-			Arguments.of(List.of(createEvent("GRANHO", "GRAUTS", FIXED_DATE)), "otherId", 0, 0),
-			Arguments.of(List.of(createEvent("type", "subtype", FIXED_DATE)), STAKEHOLDER_LEGAL_ID, 0, 0),
-			Arguments.of(List.of(createEvent("GRANHO", "GRAUTS", FIXED_DATE.minusDays(61))), STAKEHOLDER_LEGAL_ID, 0, 0),
-			Arguments.of(List.of(createEvent("GRANHO", "GRAUTS", FIXED_DATE.minusDays(30))), STAKEHOLDER_LEGAL_ID, 1, 1),
-			Arguments.of(List.of(createEvent("granho", "grauts", FIXED_DATE)), STAKEHOLDER_LEGAL_ID, 1, 1),
+			Arguments.of(List.of(createEvent(null, "GRAUTS", FIXED_TODAY)), STAKEHOLDER_LEGAL_ID, 0, 0),
+			Arguments.of(List.of(createEvent("GRANHO", null, FIXED_TODAY)), STAKEHOLDER_LEGAL_ID, 0, 0),
+			Arguments.of(List.of(createEvent("GRANHO", "GRAUTS", FIXED_TODAY)), "otherId", 0, 0),
+			Arguments.of(List.of(createEvent("type", "subtype", FIXED_TODAY)), STAKEHOLDER_LEGAL_ID, 0, 0),
+			Arguments.of(List.of(createEvent("GRANHO", "GRAUTS", FIXED_TODAY.minusDays(61))), STAKEHOLDER_LEGAL_ID, 0, 0),
+			Arguments.of(List.of(createEvent("GRANHO", "GRAUTS", FIXED_TODAY.minusDays(30))), STAKEHOLDER_LEGAL_ID, 1, 1),
+			Arguments.of(List.of(createEvent("granho", "grauts", FIXED_TODAY)), STAKEHOLDER_LEGAL_ID, 1, 1),
 			Arguments.of(List.of(
-				createEvent("granho", "grauts", FIXED_DATE),
-				createEvent("granho", "grauts", FIXED_DATE)), STAKEHOLDER_LEGAL_ID, 1, 2),
-			Arguments.of(List.of(createEvent(null, "KOMFASUTS", FIXED_DATE)), STAKEHOLDER_LEGAL_ID, 0, 0),
-			Arguments.of(List.of(createEvent("KOMFAST", null, FIXED_DATE)), STAKEHOLDER_LEGAL_ID, 0, 0),
-			Arguments.of(List.of(createEvent("KOMFAST", "KOMFASUTS", FIXED_DATE)), "otherId", 0, 0),
-			Arguments.of(List.of(createEvent("KOMFAST", "KOMFASUTS", FIXED_DATE.minusDays(61))), STAKEHOLDER_LEGAL_ID, 0, 0),
-			Arguments.of(List.of(createEvent("KOMFAST", "KOMFASUTS", FIXED_DATE.minusDays(30))), STAKEHOLDER_LEGAL_ID, 1, 1),
-			Arguments.of(List.of(createEvent("komfast", "komfasuts", FIXED_DATE)), STAKEHOLDER_LEGAL_ID, 1, 1),
+				createEvent("granho", "grauts", FIXED_TODAY),
+				createEvent("granho", "grauts", FIXED_TODAY)), STAKEHOLDER_LEGAL_ID, 1, 2),
+			Arguments.of(List.of(createEvent(null, "KOMFASUTS", FIXED_TODAY)), STAKEHOLDER_LEGAL_ID, 0, 0),
+			Arguments.of(List.of(createEvent("KOMFAST", null, FIXED_TODAY)), STAKEHOLDER_LEGAL_ID, 0, 0),
+			Arguments.of(List.of(createEvent("KOMFAST", "KOMFASUTS", FIXED_TODAY)), "otherId", 0, 0),
+			Arguments.of(List.of(createEvent("KOMFAST", "KOMFASUTS", FIXED_TODAY.minusDays(61))), STAKEHOLDER_LEGAL_ID, 0, 0),
+			Arguments.of(List.of(createEvent("KOMFAST", "KOMFASUTS", FIXED_TODAY.minusDays(30))), STAKEHOLDER_LEGAL_ID, 1, 1),
+			Arguments.of(List.of(createEvent("komfast", "komfasuts", FIXED_TODAY)), STAKEHOLDER_LEGAL_ID, 1, 1),
 			Arguments.of(List.of(
-				createEvent("KOMFAST", "KOMFASUTS", FIXED_DATE),
-				createEvent("GRANHO", "GRAUTS", FIXED_DATE)), STAKEHOLDER_LEGAL_ID, 1, 2));
+				createEvent("KOMFAST", "KOMFASUTS", FIXED_TODAY),
+				createEvent("GRANHO", "GRAUTS", FIXED_TODAY)), STAKEHOLDER_LEGAL_ID, 1, 2));
 	}
 
 	private static Stream<Arguments> filterErrandsForApplicantArgumentProvider() {
@@ -122,16 +115,20 @@ class ByggrFilterUtilityTest {
 	@ParameterizedTest
 	@MethodSource("filterNeighborhoodNotificationsArgumentProvider")
 	void filterNeighborhoodNotifications(final List<Event> events, final String identifier, final int expectedErrandsSize, final int expectedEventsSize) {
-		// Act
-		final var errands = byggrFilterUtility.filterNeighborhoodNotifications(List.of(
-			ByggrErrandDto.builder()
-				.withEvents(events)
-				.build()), identifier);
+		// Act - pin the clock so the 60-day cutoff in the filter is deterministic
+		try (final var localDateMock = mockStatic(LocalDate.class, CALLS_REAL_METHODS)) {
+			localDateMock.when(LocalDate::now).thenReturn(FIXED_TODAY);
 
-		// Assert
-		assertThat(errands).hasSize(expectedErrandsSize);
-		if (expectedErrandsSize > 0) {
-			assertThat(errands.getFirst().getEvents()).hasSize(expectedEventsSize);
+			final var errands = byggrFilterUtility.filterNeighborhoodNotifications(List.of(
+				ByggrErrandDto.builder()
+					.withEvents(events)
+					.build()), identifier);
+
+			// Assert
+			assertThat(errands).hasSize(expectedErrandsSize);
+			if (expectedErrandsSize > 0) {
+				assertThat(errands.getFirst().getEvents()).hasSize(expectedEventsSize);
+			}
 		}
 	}
 

--- a/src/test/java/se/sundsvall/byggrintegrator/service/util/ByggrFilterUtilityTest.java
+++ b/src/test/java/se/sundsvall/byggrintegrator/service/util/ByggrFilterUtilityTest.java
@@ -1,8 +1,11 @@
 package se.sundsvall.byggrintegrator.service.util;
 
+import java.time.Clock;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -21,12 +24,19 @@ import static org.springframework.test.util.ReflectionTestUtils.setField;
 @ExtendWith(MockitoExtension.class)
 class ByggrFilterUtilityTest {
 	private static final String STAKEHOLDER_LEGAL_ID = "stakeholderLegalId";
+	private static final LocalDate FIXED_DATE = LocalDate.of(2026, 6, 11);
+	private static final Clock FIXED_CLOCK = Clock.fixed(FIXED_DATE.atStartOfDay(ZoneOffset.UTC).toInstant(), ZoneOffset.UTC);
 
 	@Mock
 	private ByggrFilterProperties byggrFilterPropertiesMock;
 
 	@InjectMocks
 	private ByggrFilterUtility byggrFilterUtility;
+
+	@BeforeEach
+	void setUp() {
+		setField(byggrFilterUtility, "clock", FIXED_CLOCK);
+	}
 
 	private static Stream<Arguments> validEventArgumentProvider() {
 		return Stream.of(
@@ -47,25 +57,25 @@ class ByggrFilterUtilityTest {
 
 	private static Stream<Arguments> filterNeighborhoodNotificationsArgumentProvider() {
 		return Stream.of(
-			Arguments.of(List.of(createEvent(null, "GRAUTS", LocalDate.now())), STAKEHOLDER_LEGAL_ID, 0, 0),
-			Arguments.of(List.of(createEvent("GRANHO", null, LocalDate.now())), STAKEHOLDER_LEGAL_ID, 0, 0),
-			Arguments.of(List.of(createEvent("GRANHO", "GRAUTS", LocalDate.now())), "otherId", 0, 0),
-			Arguments.of(List.of(createEvent("type", "subtype", LocalDate.now())), STAKEHOLDER_LEGAL_ID, 0, 0),
-			Arguments.of(List.of(createEvent("GRANHO", "GRAUTS", LocalDate.now().minusDays(61))), STAKEHOLDER_LEGAL_ID, 0, 0),
-			Arguments.of(List.of(createEvent("GRANHO", "GRAUTS", LocalDate.now().minusDays(30))), STAKEHOLDER_LEGAL_ID, 1, 1),
-			Arguments.of(List.of(createEvent("granho", "grauts", LocalDate.now())), STAKEHOLDER_LEGAL_ID, 1, 1),
+			Arguments.of(List.of(createEvent(null, "GRAUTS", FIXED_DATE)), STAKEHOLDER_LEGAL_ID, 0, 0),
+			Arguments.of(List.of(createEvent("GRANHO", null, FIXED_DATE)), STAKEHOLDER_LEGAL_ID, 0, 0),
+			Arguments.of(List.of(createEvent("GRANHO", "GRAUTS", FIXED_DATE)), "otherId", 0, 0),
+			Arguments.of(List.of(createEvent("type", "subtype", FIXED_DATE)), STAKEHOLDER_LEGAL_ID, 0, 0),
+			Arguments.of(List.of(createEvent("GRANHO", "GRAUTS", FIXED_DATE.minusDays(61))), STAKEHOLDER_LEGAL_ID, 0, 0),
+			Arguments.of(List.of(createEvent("GRANHO", "GRAUTS", FIXED_DATE.minusDays(30))), STAKEHOLDER_LEGAL_ID, 1, 1),
+			Arguments.of(List.of(createEvent("granho", "grauts", FIXED_DATE)), STAKEHOLDER_LEGAL_ID, 1, 1),
 			Arguments.of(List.of(
-				createEvent("granho", "grauts", LocalDate.now()),
-				createEvent("granho", "grauts", LocalDate.now())), STAKEHOLDER_LEGAL_ID, 1, 2),
-			Arguments.of(List.of(createEvent(null, "KOMFASUTS", LocalDate.now())), STAKEHOLDER_LEGAL_ID, 0, 0),
-			Arguments.of(List.of(createEvent("KOMFAST", null, LocalDate.now())), STAKEHOLDER_LEGAL_ID, 0, 0),
-			Arguments.of(List.of(createEvent("KOMFAST", "KOMFASUTS", LocalDate.now())), "otherId", 0, 0),
-			Arguments.of(List.of(createEvent("KOMFAST", "KOMFASUTS", LocalDate.now().minusDays(61))), STAKEHOLDER_LEGAL_ID, 0, 0),
-			Arguments.of(List.of(createEvent("KOMFAST", "KOMFASUTS", LocalDate.now().minusDays(30))), STAKEHOLDER_LEGAL_ID, 1, 1),
-			Arguments.of(List.of(createEvent("komfast", "komfasuts", LocalDate.now())), STAKEHOLDER_LEGAL_ID, 1, 1),
+				createEvent("granho", "grauts", FIXED_DATE),
+				createEvent("granho", "grauts", FIXED_DATE)), STAKEHOLDER_LEGAL_ID, 1, 2),
+			Arguments.of(List.of(createEvent(null, "KOMFASUTS", FIXED_DATE)), STAKEHOLDER_LEGAL_ID, 0, 0),
+			Arguments.of(List.of(createEvent("KOMFAST", null, FIXED_DATE)), STAKEHOLDER_LEGAL_ID, 0, 0),
+			Arguments.of(List.of(createEvent("KOMFAST", "KOMFASUTS", FIXED_DATE)), "otherId", 0, 0),
+			Arguments.of(List.of(createEvent("KOMFAST", "KOMFASUTS", FIXED_DATE.minusDays(61))), STAKEHOLDER_LEGAL_ID, 0, 0),
+			Arguments.of(List.of(createEvent("KOMFAST", "KOMFASUTS", FIXED_DATE.minusDays(30))), STAKEHOLDER_LEGAL_ID, 1, 1),
+			Arguments.of(List.of(createEvent("komfast", "komfasuts", FIXED_DATE)), STAKEHOLDER_LEGAL_ID, 1, 1),
 			Arguments.of(List.of(
-				createEvent("KOMFAST", "KOMFASUTS", LocalDate.now()),
-				createEvent("GRANHO", "GRAUTS", LocalDate.now())), STAKEHOLDER_LEGAL_ID, 1, 2));
+				createEvent("KOMFAST", "KOMFASUTS", FIXED_DATE),
+				createEvent("GRANHO", "GRAUTS", FIXED_DATE)), STAKEHOLDER_LEGAL_ID, 1, 2));
 	}
 
 	private static Stream<Arguments> filterErrandsForApplicantArgumentProvider() {

--- a/src/test/java/se/sundsvall/byggrintegrator/service/util/ByggrFilterUtilityTest.java
+++ b/src/test/java/se/sundsvall/byggrintegrator/service/util/ByggrFilterUtilityTest.java
@@ -1,6 +1,7 @@
 package se.sundsvall.byggrintegrator.service.util;
 
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -23,7 +24,7 @@ import static org.springframework.test.util.ReflectionTestUtils.setField;
 @ExtendWith(MockitoExtension.class)
 class ByggrFilterUtilityTest {
 	private static final String STAKEHOLDER_LEGAL_ID = "stakeholderLegalId";
-	private static final LocalDate FIXED_TODAY = LocalDate.of(2026, 6, 11);
+	private static final LocalDate FIXED_TODAY = LocalDate.of(2026, Month.JUNE, 11);
 
 	@Mock
 	private ByggrFilterProperties byggrFilterPropertiesMock;

--- a/src/test/java/se/sundsvall/byggrintegrator/service/util/ByggrFilterUtilityTest.java
+++ b/src/test/java/se/sundsvall/byggrintegrator/service/util/ByggrFilterUtilityTest.java
@@ -38,10 +38,10 @@ class ByggrFilterUtilityTest {
 			Arguments.of(createEvent("granho", "grauts"), true),
 			Arguments.of(createEvent("GRANHO", "GRAUTS"), true),
 			Arguments.of(createEvent("KOMFAST", null), false),
-			Arguments.of(createEvent(null, "KOMFASVA"), false),
-			Arguments.of(createEvent("komfast", "komfasva"), true),
-			Arguments.of(createEvent("KOMFAST", "KOMFASVA"), true),
-			Arguments.of(createEvent("GRANHO", "KOMFASVA"), false),
+			Arguments.of(createEvent(null, "KOMFASUTS"), false),
+			Arguments.of(createEvent("komfast", "komfasuts"), true),
+			Arguments.of(createEvent("KOMFAST", "KOMFASUTS"), true),
+			Arguments.of(createEvent("GRANHO", "KOMFASUTS"), false),
 			Arguments.of(createEvent("KOMFAST", "GRAUTS"), false));
 	}
 
@@ -57,14 +57,14 @@ class ByggrFilterUtilityTest {
 			Arguments.of(List.of(
 				createEvent("granho", "grauts", LocalDate.now()),
 				createEvent("granho", "grauts", LocalDate.now())), STAKEHOLDER_LEGAL_ID, 1, 2),
-			Arguments.of(List.of(createEvent(null, "KOMFASVA", LocalDate.now())), STAKEHOLDER_LEGAL_ID, 0, 0),
+			Arguments.of(List.of(createEvent(null, "KOMFASUTS", LocalDate.now())), STAKEHOLDER_LEGAL_ID, 0, 0),
 			Arguments.of(List.of(createEvent("KOMFAST", null, LocalDate.now())), STAKEHOLDER_LEGAL_ID, 0, 0),
-			Arguments.of(List.of(createEvent("KOMFAST", "KOMFASVA", LocalDate.now())), "otherId", 0, 0),
-			Arguments.of(List.of(createEvent("KOMFAST", "KOMFASVA", LocalDate.now().minusDays(61))), STAKEHOLDER_LEGAL_ID, 0, 0),
-			Arguments.of(List.of(createEvent("KOMFAST", "KOMFASVA", LocalDate.now().minusDays(30))), STAKEHOLDER_LEGAL_ID, 1, 1),
-			Arguments.of(List.of(createEvent("komfast", "komfasva", LocalDate.now())), STAKEHOLDER_LEGAL_ID, 1, 1),
+			Arguments.of(List.of(createEvent("KOMFAST", "KOMFASUTS", LocalDate.now())), "otherId", 0, 0),
+			Arguments.of(List.of(createEvent("KOMFAST", "KOMFASUTS", LocalDate.now().minusDays(61))), STAKEHOLDER_LEGAL_ID, 0, 0),
+			Arguments.of(List.of(createEvent("KOMFAST", "KOMFASUTS", LocalDate.now().minusDays(30))), STAKEHOLDER_LEGAL_ID, 1, 1),
+			Arguments.of(List.of(createEvent("komfast", "komfasuts", LocalDate.now())), STAKEHOLDER_LEGAL_ID, 1, 1),
 			Arguments.of(List.of(
-				createEvent("KOMFAST", "KOMFASVA", LocalDate.now()),
+				createEvent("KOMFAST", "KOMFASUTS", LocalDate.now()),
 				createEvent("GRANHO", "GRAUTS", LocalDate.now())), STAKEHOLDER_LEGAL_ID, 1, 2));
 	}
 
@@ -144,7 +144,7 @@ class ByggrFilterUtilityTest {
 		setField(byggrFilterUtility, "unwantedSubtypes", List.of("GRASVA"));
 
 		final var errands = List.of(ByggrErrandDto.builder()
-			.withEvents(List.of(createEvent("KOMFAST", "KOMFASVA"), createEvent("KOMFAST", "GRASVA")))
+			.withEvents(List.of(createEvent("KOMFAST", "KOMFASUTS"), createEvent("KOMFAST", "GRASVA")))
 			.build());
 
 		// Act and assert


### PR DESCRIPTION
Fixes the event filtering for `GET /{municipalityId}/neighborhood-notifications/{identifier}/errands`.

For KOMFAST events the filter required subtype `KOMFASVA` (svar — *responses*), but it should require `KOMFASUTS` (utskick — the *dispatch* of notifications/communication to property owners). The previous value let the wrong events qualify an errand for the response.

`WANTED_TYPE_SUBTYPE_PAIRS` in `ByggrFilterUtility` is changed from `KOMFASVA` to `KOMFASUTS`, and the Javadoc, endpoint description, OpenAPI spec and unit tests are aligned. `ByggrFilterUtilityTest` passes (36 tests).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).